### PR TITLE
Al/improve robot dj (#79)

### DIFF
--- a/src/app/playlist/playlist.component.ts
+++ b/src/app/playlist/playlist.component.ts
@@ -44,6 +44,10 @@ export class PlaylistComponent implements OnInit, OnDestroy {
     console.log('Clicked to remove track:', i);
     // console.warn('Remove Track:', track);
     this.playlistService.remove(track.key, i);
+    if (track.player) {
+      console.log(`track came from pool, updating added_at time there... ${track.name}`);
+      this.playlistService.saveTrack(track);
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/playlist/playlist.component.ts
+++ b/src/app/playlist/playlist.component.ts
@@ -41,11 +41,9 @@ export class PlaylistComponent implements OnInit, OnDestroy {
   removeTrack(track: any, i: number): void {
     // add 1 to the index because we slice off the first track
     i++;
-    console.log('Clicked to remove track:', i);
-    // console.warn('Remove Track:', track);
+    console.log(`Clicked to remove ${track.name}`);
     this.playlistService.remove(track.key, i);
     if (track.player) {
-      console.log(`track came from pool, updating added_at time there... ${track.name}`);
       this.playlistService.saveTrack(track);
     }
   }

--- a/src/app/shared/services/playlist.service.ts
+++ b/src/app/shared/services/playlist.service.ts
@@ -303,24 +303,18 @@ export class PlaylistService {
       }
   }
 
-  /** Method to save track in Firebase secondary list */
+  /** Method to save track in station pool */
   saveTrack(track: Track): any {
-    // console.log('Track to save in Secondary List:', track);
-    // Verify if it's default robot track
-    if (track.id === '0RbfwabR0mycfvZOduSIOO') {
-      // console.log('Default track does not need to be saved in previous played tracks');
-    } else if (track.player) {
-      if (track.player.auto) {
-        // console.log('Random track does not need to be saved again in previous played tracks');
-      }
-    } else {
-      // Clean track Object
-      delete track.expires_at;
-      // Save track in previous played list
-      this.db.list(this.previouslistUrl).set(track.id, track);
-      console.log(`${track.name} saved to previous list`);
-      this.pruneTracks(40);
-    }
+    
+    // Clean track Object
+    delete track.expires_at;
+    // not sure why this is there TBH 🤔
+    delete track.key;
+
+    this.db.list(this.previouslistUrl).set(track.id, track);
+    console.log(`${track.name} saved to previous list`);
+    this.pruneTracks(40);
+    
   }
 
   private getTime(): number {


### PR DESCRIPTION
First pass on robot DJ improvements in #79... we improve and update `added_at` property of tracks in the pool so we always know when a track last showed up in the playlist... then, robot DJ pulls oldest tracks according to `added_at` so your tracks basically play in loop instead of in random order. 

We still limit the pool to 40 tracks total. 

Strongly considering as a follow-up: Removing a track from the playlist removes it from the pool as well (assuming it was auto-added in the first place) to make that behavior consistent with "skip" behavior that removes the track from the pool. The alternative would be to build a separate button that explicitly removes tracks from the station pool. 